### PR TITLE
Add basic TypeScript server

### DIFF
--- a/ts-server/README.md
+++ b/ts-server/README.md
@@ -1,0 +1,25 @@
+# Nmap Dashboard TypeScript Server
+
+This folder contains a simple Express-based server that provides
+API endpoints similar to the original Django application.
+
+## Setup
+
+1. Install dependencies:
+   ```sh
+   npm install
+   ```
+2. Build the project:
+   ```sh
+   npm run build
+   ```
+3. Run the server:
+   ```sh
+   npm start
+   ```
+
+During development you can run `npm run dev` if you have
+`ts-node` installed.
+
+The server reads scan files from `/opt/xml` and uses `/root/token.sha256`
+for token authentication (send the token in the `X-Auth-Token` header).

--- a/ts-server/package.json
+++ b/ts-server/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "nmap-dashboard-ts",
+  "version": "0.1.0",
+  "description": "TypeScript version of Nmap Dashboard",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "ts-node src/server.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "xml2js": "^0.6.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/node": "^20.6.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.2"
+  }
+}

--- a/ts-server/src/server.ts
+++ b/ts-server/src/server.ts
@@ -1,0 +1,82 @@
+import express from 'express';
+import { Request, Response, NextFunction } from 'express';
+import fs from 'fs';
+import crypto from 'crypto';
+import { exec } from 'child_process';
+import { parseStringPromise } from 'xml2js';
+import path from 'path';
+
+const app = express();
+app.use(express.json());
+
+const XML_DIR = '/opt/xml';
+const NOTES_DIR = '/opt/notes';
+
+function tokenCheck(token: string): boolean {
+  try {
+    const tokenHash = fs.readFileSync('/root/token.sha256', 'utf8').trim();
+    const provided = crypto.createHash('sha256').update(token).digest('hex');
+    return provided === tokenHash;
+  } catch {
+    return false;
+  }
+}
+
+function authMiddleware(req: Request, res: Response, next: NextFunction) {
+  const token = req.headers['x-auth-token'];
+  if (typeof token === 'string' && tokenCheck(token)) {
+    return next();
+  }
+  return res.status(401).json({ error: 'Unauthorized' });
+}
+
+// List available scan XML files
+app.get('/api/scans', authMiddleware, (req: Request, res: Response) => {
+  try {
+    const files = fs.readdirSync(XML_DIR).filter(f => f.endsWith('.xml'));
+    return res.json({ files });
+  } catch (err) {
+    return res.status(500).json({ error: 'Unable to list scans' });
+  }
+});
+
+// Get host details from a scan
+app.get('/api/scan/:file/host/:address', authMiddleware, async (req: Request, res: Response) => {
+  const file = path.basename(req.params.file);
+  const address = req.params.address;
+  try {
+    const xmlPath = path.join(XML_DIR, file);
+    const xmlData = fs.readFileSync(xmlPath, 'utf8');
+    const parsed = await parseStringPromise(xmlData);
+    const hosts = parsed.nmaprun.host;
+    for (const host of hosts) {
+      const addr = host.address?.['$']?.addr;
+      if (addr === address) {
+        return res.json({ host });
+      }
+    }
+    return res.status(404).json({ error: 'Host not found' });
+  } catch (err) {
+    return res.status(500).json({ error: 'Failed to parse scan' });
+  }
+});
+
+// Start a new scan
+app.post('/api/scan', authMiddleware, (req: Request, res: Response) => {
+  const { filename, target, params } = req.body;
+  if (!/^[\w.-]+$/.test(filename)) {
+    return res.status(400).json({ error: 'Invalid filename' });
+  }
+  const cmd = `nmap ${params} -oX ${path.join(XML_DIR, filename)} ${target}`;
+  exec(cmd, err => {
+    if (err) {
+      return res.status(500).json({ error: 'nmap failed' });
+    }
+    return res.json({ ok: true });
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/ts-server/tsconfig.json
+++ b/ts-server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- implement a small Express server in TypeScript
- add project config and instructions

## Testing
- `npx tsc -p ts-server/tsconfig.json` *(fails: Cannot find module 'express')*